### PR TITLE
bind transit elements only when transit is enabled

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,14 @@
 			<version>0.11.0-2018w44</version>
 		</dependency>
 
+        <dependency>
+			<groupId>org.matsim</groupId>
+			<artifactId>matsim</artifactId>
+            <type>test-jar</type>
+			<version>0.11.0-2018w44</version>
+			<scope>test</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>com.github.matsim-eth</groupId>
 			<artifactId>location_assignment</artifactId>

--- a/src/test/java/ch/ethz/matsim/baseline_scenario/transit/TransitModuleTest.java
+++ b/src/test/java/ch/ethz/matsim/baseline_scenario/transit/TransitModuleTest.java
@@ -1,0 +1,26 @@
+package ch.ethz.matsim.baseline_scenario.transit;
+
+import ch.sbb.matsim.routing.pt.raptor.SwissRailRaptorModule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.matsim.core.config.Config;
+import org.matsim.core.controler.Controler;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.testcases.MatsimTestUtils;
+
+public class TransitModuleTest {
+    @Rule
+    public final MatsimTestUtils utils = new MatsimTestUtils();
+
+    @Test
+    public void testWorksWithTransitDisabled() {
+        final Config config = utils.createConfig();
+        config.transit().setUseTransit(false);
+        config.controler().setLastIteration(0);
+
+        final Controler controler = new Controler(ScenarioUtils.createScenario(config));
+        controler.addOverridingModule(new SwissRailRaptorModule());
+        controler.addOverridingModule(new BaselineTransitModule());
+        controler.run();
+    }
+}


### PR DESCRIPTION
fails otherwise, as SwissRailRaptor binds its elements only when transit
is enabled. I had a look on their side, considering it might actually be
a better design to always bind elements and just "activate" them when
transit is enabled... But it is actually not that clear.
